### PR TITLE
Detect xdai transfers from the bridge

### DIFF
--- a/assets/src/Asset.d.ts
+++ b/assets/src/Asset.d.ts
@@ -36,6 +36,8 @@ export default class Asset {
   getMaximumSendableBalance(account: string, recipient?: string): Promise<string>;
   getSendFee(): Promise<string>;
   getGrowthRate(account: string): Promise<string>;
+  startWatchingAddress(address: string): any;
+  poll(callback: Function, internal: number): any;
   send(params: SendParams): Promise<any>;
   supportsMessages(): boolean;
   getWeb3(): any;
@@ -43,4 +45,5 @@ export default class Asset {
   stop(): void;
 
   protected _send(params: SendParams): Promise<any>;
+  protected _getBlockTimestamp(blockNum: string | number): Promise<number | string>;
 }

--- a/assets/src/ERC20Asset.d.ts
+++ b/assets/src/ERC20Asset.d.ts
@@ -4,10 +4,13 @@ import { Contract } from 'web3-eth-contract';
 interface ERC20Constructor extends AssetConstructor {
   address: string,
   abi?: object,
+  pollInterval?: number,
+  type?: string,
 }
 
 export default class ERC20Asset extends Asset {
   public address: string;
+  protected _pollInterval: number;
 
   constructor(props: ERC20Constructor);
   allowance(from:string, to:string): Promise<string>;

--- a/assets/src/NativeAsset.d.ts
+++ b/assets/src/NativeAsset.d.ts
@@ -1,3 +1,7 @@
 import Asset from './Asset';
 
-export default class ERC20Asset extends Asset {}
+export default class NativeAsset extends Asset {
+    protected _pollInterval: number;
+
+    scanBlocks(address: string, startBlock: string | number, toBlock: string | number): Promise<any>
+}

--- a/assets/src/abi/IXDaiBridge.json
+++ b/assets/src/abi/IXDaiBridge.json
@@ -1,0 +1,24 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "transactionHash",
+        "type": "bytes32"
+      }
+    ],
+    "name": "AffirmationCompleted",
+    "type": "event"
+  }
+]

--- a/assets/src/xdai.js
+++ b/assets/src/xdai.js
@@ -1,6 +1,49 @@
 const NativeAsset = require('./NativeAsset');
+const IXDaiBridge = require('./abi/IXDaiBridge.json');
 
-module.exports = new NativeAsset({
+class XDaiNativeAsset extends NativeAsset {
+  constructor(props) {
+    super(props);
+    this.bridgeAddress = '0x7301cfa0e1756b71869e93d4e4dca5c7d0eb0aa6';
+  }
+
+  async scanBlocks(address, fromBlock, toBlock) {
+    await super.scanBlocks(address, fromBlock, toBlock);
+
+    const web3 = this.getWeb3();
+    const contract = new web3.eth.Contract(IXDaiBridge, this.bridgeAddress);
+    const events = await contract.getPastEvents('AffirmationCompleted', {
+      fromBlock,
+      toBlock
+    });
+    const filteredEvents = events.filter(event => event.returnValues.recipient.toLowerCase() === address.toLowerCase());
+
+    for (const event of filteredEvents) {
+      this.core.addHistoryEvent({
+        id: `${event.transactionHash}-${event.logIndex}`,
+        asset: this.id,
+        type: 'send',
+        value: event.returnValues.value.toString(),
+        from: this.bridgeAddress,
+        to: event.returnValues.recipient,
+        tx: event.transactionHash,
+        timestamp: await this._getBlockTimestamp(event.blockNumber)
+      });
+    }
+  }
+
+  async getTx(txHash) {
+    const historyEvents = this.core.getHistoryEvents({asset: this.id, account: this.bridgeAddress})
+    const eventMatch = historyEvents.filter(e => e.tx === txHash)
+    if (eventMatch.length > 0) {
+      return eventMatch[0];
+    } else {
+      return super.getTx(txHash);
+    }
+  }
+}
+
+module.exports = new XDaiNativeAsset({
   id: 'xdai',
   name: 'xDai',
   network: '100',


### PR DESCRIPTION
As a continuation to improve the UX of the exchange operations in https://github.com/burner-wallet/burner-wallet-2/pull/21, this PR extends the `xdai` asset definition to detect when xdai native tokens are minted to the account as a result of exchanging DAI to xDai using the bridge. 

With this improvement, the UI will be able to display the incoming tokens to the account in the recent activity list.
![exchange](https://user-images.githubusercontent.com/4614574/79265428-76a03500-7e6c-11ea-89b5-d79455ef2c38.png)

The `getTx` method was updated to return the data stored in the `HistoryEvents` if it is a transaction that includes a registered event from the bridge. In that case, it will display that information in the `Transaction Receipt` details instead of retrieving and showing the actual information of the transaction that will no make much sense because it is a call from a validator to the bridge address with zero value.
![receipt](https://user-images.githubusercontent.com/4614574/79265962-460ccb00-7e6d-11ea-9570-4c0349ed974a.png)

Also, I updated some of the assets types to match the implementation.